### PR TITLE
Avoid a CRITICAL error in case of <img> without src attribute

### DIFF
--- a/pelican/plugins/featured_image/featured_image.py
+++ b/pelican/plugins/featured_image/featured_image.py
@@ -30,7 +30,7 @@ def images_extraction(instance):
         if not featured_image:
             soup = BeautifulSoup(instance._content, "html.parser")
             imageTag = soup.find("img")
-            if imageTag:
+            if imageTag and imageTag.get("src"):
                 featured_image = imageTag["src"]
 
         # Set the attribute to content instance

--- a/pelican/plugins/featured_image/test_featured_image.py
+++ b/pelican/plugins/featured_image/test_featured_image.py
@@ -41,6 +41,22 @@ class TestFeaturedImage(unittest.TestCase):
         featured_image.images_extraction(article)
         self.assertEqual(article.featured_image, TEST_CONTENT_IMAGE_URL)
 
+    def test_extract_image_from_content_and_img_has_no_src(self):
+        args = {
+            "content": (
+                str(generate_lorem_ipsum(n=3, html=True))
+                + "<img>"
+                + str(generate_lorem_ipsum(n=2, html=True))
+            ),
+            "metadata": {
+                "summary": TEST_SUMMARY_WITHOUTIMAGE,
+            },
+        }
+
+        article = Article(**args)
+        featured_image.images_extraction(article)
+        self.assertEqual(article.featured_image, None)
+
     def test_extract_image_from_summary(self):
         args = {
             "content": TEST_CONTENT,


### PR DESCRIPTION
This is a port of PR https://github.com/getpelican/pelican-plugins/pull/1411 to this repo.

Without this fix, when an article contains an `<img>` with no `src` attribute, Pelican crashes:
```
Traceback (most recent call last):
  File "~/.local/share/virtualenvs/ludochaordic/lib/python3.10/site-packages/pelican/__init__.py", line 679, in main
    pelican.run()
  File "~/.local/share/virtualenvs/ludochaordic/lib/python3.10/site-packages/pelican/__init__.py", line 133, in run
    signals.all_generators_finalized.send(generators)
  File "~/.local/share/virtualenvs/ludochaordic/lib/python3.10/site-packages/blinker/base.py", line 307, in send
    result = receiver(sender, **kwargs)
  File "~/pelican-plugins/representative_image/representative_image.py", line 48, in run_plugin
    images_extraction(article)
  File "~/pelican-plugins/representative_image/representative_image.py", line 35, in images_extraction
    representativeImage = imageTag['src']
  File "~/.local/share/virtualenvs/ludochaordic/lib/python3.10/site-packages/bs4/element.py", line 2206, in __getitem__
    return self.attrs[key]
KeyError: 'src'
[15:38:22] CRITICAL [15:38:22] [pelican] CRITICAL KeyError: 'src'
```